### PR TITLE
Add functions generating reboot packets to X-series

### DIFF
--- a/src/dynamixel/servos/base_servo.hpp
+++ b/src/dynamixel/servos/base_servo.hpp
@@ -170,6 +170,11 @@ namespace dynamixel {
                 throw errors::Error("ping not implemented in model");
             }
 
+            virtual InstructionPacket<protocol_t> reboot() const
+            {
+                throw errors::Error("reboot not implemented in model");
+            }
+
             // =================================================================
             // Position-specific
 

--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -93,6 +93,7 @@ namespace dynamixel {
             typedef typename ModelTraits<Model>::protocol_t protocol_t;
             typedef typename ModelTraits<Model>::CT ct_t;
             typedef instructions::Ping<protocol_t> ping_t;
+            typedef instructions::Reboot<dynamixel::protocols::Protocol2> reboot_t;
             typedef instructions::Read<protocol_t> read_t;
             typedef instructions::Write<protocol_t> write_t;
             typedef instructions::RegWrite<protocol_t> reg_write_t;

--- a/src/dynamixel/servos/xh430_v210.hpp
+++ b/src/dynamixel/servos/xh430_v210.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xh430_v350.hpp
+++ b/src/dynamixel/servos/xh430_v350.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xh430_w210.hpp
+++ b/src/dynamixel/servos/xh430_w210.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xh430_w350.hpp
+++ b/src/dynamixel/servos/xh430_w350.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xl320.hpp
+++ b/src/dynamixel/servos/xl320.hpp
@@ -110,6 +110,17 @@ namespace dynamixel {
             READ_FIELD(present_load);
             READ_FIELD(hardware_error_status);
             READ_WRITE_FIELD(punch);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xm430_w210.hpp
+++ b/src/dynamixel/servos/xm430_w210.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xm430_w250.hpp
+++ b/src/dynamixel/servos/xm430_w250.hpp
@@ -168,6 +168,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xm430_w350.hpp
+++ b/src/dynamixel/servos/xm430_w350.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xm540_w150.hpp
+++ b/src/dynamixel/servos/xm540_w150.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }

--- a/src/dynamixel/servos/xm540_w270.hpp
+++ b/src/dynamixel/servos/xm540_w270.hpp
@@ -174,6 +174,17 @@ namespace dynamixel {
             // READ_FIELD(current);
             READ_FIELD(speed_trajectory);
             READ_FIELD(position_trajectory);
+
+            // rebooting functions only for Protocol2
+            static inline InstructionPacket<protocol_t> reboot(typename Servo<Model>::protocol_t::id_t id)
+            {
+                return reboot_t(id);
+            }
+
+            InstructionPacket<protocol_t> reboot() const override
+            {
+                return reboot_t(this->_id);
+            }
         };
     }
 }


### PR DESCRIPTION
There is no Interface to support rebooting motors. This PR adds such interfaces to X-series actuator classes. 